### PR TITLE
Add manifest and default configuration options for abstract files

### DIFF
--- a/abstract.mmd
+++ b/abstract.mmd
@@ -1,0 +1,1 @@
+This file contains the standard abstract for your document.

--- a/default_config
+++ b/default_config
@@ -1,0 +1,4 @@
+{
+  "abstract": "abstract.tex",
+  "public_abstract": "publicabstract.tex"
+}

--- a/manifest
+++ b/manifest
@@ -1,0 +1,6 @@
+{
+  "metadata.tex": "metadata.tex",
+  "paper.mmd": "frontmatter.mmd",
+  "abstract.mmd": "abstract.mmd",
+  "publicabstract.mmd": "publicabstract.mmd"
+}

--- a/publicabstract.mmd
+++ b/publicabstract.mmd
@@ -1,0 +1,1 @@
+This file contains the public abstract, written for a general audience.


### PR DESCRIPTION
This addresses the feature request in #5, using new features in scriptorium providing the capability for templates to define a manifest for new documents, and default values for configuration options. This automatically generates default abstract and public abstract files as part of document creation.